### PR TITLE
fix(settings): order parseSettings before initBuckets; dedupe color defaults

### DIFF
--- a/src/heatmapUtils.ts
+++ b/src/heatmapUtils.ts
@@ -33,7 +33,7 @@ import { ColorHelper } from "powerbi-visuals-utils-colorutils";
 import maxBy from "lodash.maxby";
 
 import { IColorArray, TableHeatMapChartData } from "./dataInterfaces";
-import { BaseLabelCardSettings, colorbrewer, SettingsModel, YAxisLabelsSettings } from "./settings";
+import { BaseLabelCardSettings, colorbrewer, GeneralSettings, SettingsModel, YAxisLabelsSettings } from "./settings";
 
 export const DimmedOpacity: number = 0.4;
 export const DefaultOpacity: number = 1.0;
@@ -176,8 +176,8 @@ export function parseSettings(colorHelper: ColorHelper, settingsModel: SettingsM
         settingsModel.general.stroke = foregroundColor;
         settingsModel.general.textColor = foregroundColor;
     } else {
-        settingsModel.general.stroke = "#E6E6E6";
-        settingsModel.general.textColor = "#AAAAAA";
+        settingsModel.general.stroke = GeneralSettings.DefaultStroke;
+        settingsModel.general.textColor = GeneralSettings.DefaultTextColor;
     }
 
     return settingsModel;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -383,6 +383,8 @@ export class GeneralSettings extends FormattingSettingsCompositeCard {
     public static BucketCountMinLimitWithGradientMiddle: number = 3;
     public static DefaultBucketCount: number = 5;
     public static ColorbrewerMaxBucketCount: number = 14;
+    public static DefaultStroke: string = "#E6E6E6";
+    public static DefaultTextColor: string = "#AAAAAA";
 
     public enableColorbrewer = new formattingSettings.ToggleSwitch({
         name: "enableColorbrewer",
@@ -449,8 +451,8 @@ export class GeneralSettings extends FormattingSettingsCompositeCard {
         }
     });
 
-    public stroke: string = "#E6E6E6";
-    public textColor: string = "#AAAAAA";
+    public stroke: string = GeneralSettings.DefaultStroke;
+    public textColor: string = GeneralSettings.DefaultTextColor;
 
     private paletteGroup: FormattingSettingsGroup = new formattingSettings.Group({
         name: "paletteGroup",

--- a/src/visual.ts
+++ b/src/visual.ts
@@ -325,8 +325,10 @@ export class TableHeatMap implements IVisual {
             this.processViewMode(options);
 
             this.settingsModel = this.formattingSettingsService.populateFormattingSettingsModel(SettingsModel, options.dataViews[0]);
-            this.settingsModel.initBuckets();
+            // parseSettings can flip enableColorbrewer/activateGradientMiddle (e.g. in high-contrast mode),
+            // so it must run before initBuckets() so bucket constraints match the final, rendered mode.
             this.settingsModel = parseSettings(this.colorHelper, this.settingsModel);
+            this.settingsModel.initBuckets();
 
             this.render(this.converter(options.dataViews[0]), this.settingsModel, options.viewport);
             this.host.eventService.renderingFinished(options);

--- a/test/visualTest.ts
+++ b/test/visualTest.ts
@@ -43,7 +43,7 @@ import { TableHeatMap } from "../src/visual";
 import { ClickEventType, createColorPalette, d3Click, parseColorString, renderTimeout } from "powerbi-visuals-utils-testutils";
 import { ColorHelper } from "powerbi-visuals-utils-colorutils";
 import { TableHeatMapChartData } from "../src/dataInterfaces";
-import { colorbrewer, SettingsModel } from "../src/settings";
+import { colorbrewer, GeneralSettings, SettingsModel } from "../src/settings";
 import {
     getOpacity, DimmedOpacity, DefaultOpacity, DimmedColor,
     isDataViewValid, textLimit,
@@ -510,6 +510,20 @@ describe("TableHeatmap", () => {
                     visualBuilder.updateRenderTimeout(dataView, () => {
                         const rects = Array.from(visualBuilder.rects!);
                         expect(isColorAppliedToElements(rects, foregroundColor, "stroke")).toBeTrue();
+                        done();
+                    }, DefaultTimeout);
+                });
+
+                it("recomputes bucket constraints for the post-parse mode (parseSettings runs before initBuckets)", (done) => {
+                    // In high-contrast mode parseSettings forces enableColorbrewer and activateGradientMiddle off.
+                    // Because parseSettings runs before initBuckets, the bucket constraints must reflect that final
+                    // custom-gradient mode (min 1, max 18) rather than being stuck at the pre-parse colorbrewer limits.
+                    visualBuilder.updateRenderTimeout(dataView, () => {
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        const general = (visualBuilder as any).visual.settingsModel.general;
+                        expect(general.enableColorbrewer.value).toBeFalse();
+                        expect(general.buckets.options.minValue.value).toBe(GeneralSettings.BucketCountMinLimit);
+                        expect(general.buckets.options.maxValue.value).toBe(GeneralSettings.BucketCountMaxLimit);
                         done();
                     }, DefaultTimeout);
                 });


### PR DESCRIPTION
## Summary

Small follow-up cleanups after #221 (gradient middle feature).

### Changes
- **Run `parseSettings()` before `initBuckets()`** in `update()`. `parseSettings()` can flip `enableColorbrewer` / `activateGradientMiddle` (e.g. in high-contrast mode), so running it first ensures bucket constraints (`buckets.options.min/maxValue`, `CurrentBucketCount`) match the final rendered mode instead of being stuck at the pre-parse Colorbrewer limits.
- **Dedupe `stroke` / `textColor` defaults** into `GeneralSettings.DefaultStroke` / `GeneralSettings.DefaultTextColor` constants, referenced from both `GeneralSettings` and `parseSettings()` to avoid future drift.
- **Add a high-contrast regression test** that drives the full `update()` flow and asserts the post-parse bucket constraints (`minValue = 1`, `maxValue = 18`). This test fails on the old `initBuckets → parseSettings` order and passes on the new one, guarding the fix against future reordering.

### Notes
- Out of scope: the start/end Colorbrewer write-back rework (single-source-of-truth color sync via `persistProperties`) will be a separate PR.

### Validation
- `eslint src/` clean
- `71/71` unit tests pass
- Regression test verified to fail on the previous ordering and pass on the new one
